### PR TITLE
adding a checkbox to skip the entire test run

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 ## Tests to run
 
+Maybe we should not be running any E2E tests?
+
+- [x] run Cypress tests
+
 Please pick all tests you would like to run against this pull request
 
 - [ ] all tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "debug": "^4.3.3",
         "find-cypress-specs": "^1.15.0",
         "got": "^11.8.3",
-        "grep-tests-from-pull-requests": "^1.5.0",
+        "grep-tests-from-pull-requests": "^1.10.0",
         "prettier": "^2.3.2"
       }
     },
@@ -1657,14 +1657,20 @@
       "dev": true
     },
     "node_modules/grep-tests-from-pull-requests": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/grep-tests-from-pull-requests/-/grep-tests-from-pull-requests-1.5.0.tgz",
-      "integrity": "sha512-YFwQAiwUfvFaa9qiIIMibVyUrNrZTwpCxw/2J9IkSv5pCCdvT1fVDklfyDYq/ZDvTeSRy3IlTXdv5mu1Z2dwNA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/grep-tests-from-pull-requests/-/grep-tests-from-pull-requests-1.10.0.tgz",
+      "integrity": "sha512-p5XtTbr7oQcSdF+Vm8ysw3iJUNZI9otBhu6W4yua/T8yI7WlmifpCv9rbAtaaVda28KOsX6IZwzBsbtuYU1CQQ==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.1",
         "debug": "^4.3.3",
         "got": "^11.8.3"
+      },
+      "bin": {
+        "get-pr-body": "bin/get-pr-body.js",
+        "get-pr-comments": "bin/get-pr-comments.js",
+        "get-pr-tests": "bin/get-pr-tests.js",
+        "should-pr-run-cypress-tests": "bin/should-pr-run-cypress-tests.js"
       }
     },
     "node_modules/has": {
@@ -4888,9 +4894,9 @@
       "dev": true
     },
     "grep-tests-from-pull-requests": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/grep-tests-from-pull-requests/-/grep-tests-from-pull-requests-1.5.0.tgz",
-      "integrity": "sha512-YFwQAiwUfvFaa9qiIIMibVyUrNrZTwpCxw/2J9IkSv5pCCdvT1fVDklfyDYq/ZDvTeSRy3IlTXdv5mu1Z2dwNA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/grep-tests-from-pull-requests/-/grep-tests-from-pull-requests-1.10.0.tgz",
+      "integrity": "sha512-p5XtTbr7oQcSdF+Vm8ysw3iJUNZI9otBhu6W4yua/T8yI7WlmifpCv9rbAtaaVda28KOsX6IZwzBsbtuYU1CQQ==",
       "dev": true,
       "requires": {
         "arg": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "^4.3.3",
     "find-cypress-specs": "^1.15.0",
     "got": "^11.8.3",
-    "grep-tests-from-pull-requests": "^1.5.0",
+    "grep-tests-from-pull-requests": "^1.10.0",
     "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
# Summary

## Tests to run

Maybe we should not be running any E2E tests?

- [x] run Cypress tests

## Tests to run

Please pick all tests you would like to run against this pull request

- [ ] all tests
- [ ] tests tagged `@log`
- [ ] tests tagged `@sanity`
- [ ] tests tagged `@user`

To re-run the tests, pick the tags above then click the checkbox below

- [ ] re-run the tests

Tip: You can find all the tagged tests by running `npm run names` and `npm run tags` in this repository.

## Base URL

By default, the tests run against the baseUrl https://todomvc-no-tests-vercel.vercel.app/ Change this URL if necessary when testing a pull request deployed somewhere else.

baseUrl https://todomvc-no-tests-vercel.vercel.app/

The tags and the url is extracted using [grep-tests-from-pull-requests](https://github.com/bahmutov/grep-tests-from-pull-requests).
